### PR TITLE
FishyFacepunch doesn't Init Steam if it is already initialized

### DIFF
--- a/FishNet/Plugins/FishyFacepunch/FishyFacepunch.cs
+++ b/FishNet/Plugins/FishyFacepunch/FishyFacepunch.cs
@@ -95,7 +95,11 @@ namespace FishyFacepunch
             CreateChannelData();
 
 #if !UNITY_SERVER
-            SteamClient.Init(_steamAppID, true);
+            if (!SteamClient.IsValid) //Steam might have already been initialized by something else
+            {
+                SteamClient.Init(_steamAppID, true);
+            }
+
             SteamNetworking.AllowP2PPacketRelay(true);
 #endif
             _clientHost.Initialize(this);


### PR DESCRIPTION
This commit fixes an issue where FishyFacepunch (potentially incorrectly) assumes that Steam has not already been initialized by something else. It's a simply guard check just to make sure it doesn't attempt to initialize Steam if the client is already valid (meaning it has been initialized)