### PR TITLE
Catch SteamClient.Init failure in Initialize()

### DIFF
--- a/FishNet/Plugins/FishyFacepunch/FishyFacepunch.cs
+++ b/FishNet/Plugins/FishyFacepunch/FishyFacepunch.cs
@@ -95,12 +95,30 @@ namespace FishyFacepunch
             CreateChannelData();
 
 #if !UNITY_SERVER
-            if (!SteamClient.IsValid) //Steam might have already been initialized by something else
+            // Facepunch's SteamClient.Init throws when Steam is unavailable on the
+            // player's machine (e.g. the Steam client is mid-startup or reports
+            // "ConnectToGlobalUser failed"). FishNet runs this transport's Initialize
+            // inside NetworkManager.Awake (NetworkManager is DefaultExecutionOrder
+            // short.MinValue, so it precedes every other script). An uncaught throw
+            // here aborts NetworkManager.Awake, leaving every FishNet manager
+            // half-built and flooding the log with PredictionManager NREs each tick.
+            // Facepunch documents that callers of SteamClient.Init must catch this —
+            // so catch it: the transport comes up Steam-less and the game still
+            // boots. Steam-backed connections are unavailable, which is correct when
+            // Steam is down.
+            try
             {
-                SteamClient.Init(_steamAppID, true);
-            }
+                if (!SteamClient.IsValid) //Steam might have already been initialized by something else
+                {
+                    SteamClient.Init(_steamAppID, true);
+                }
 
-            SteamNetworking.AllowP2PPacketRelay(true);
+                SteamNetworking.AllowP2PPacketRelay(true);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogError($"[FishyFacepunch] Steam initialization failed; Steam transport is unavailable this session. {e.Message}");
+            }
 #endif
             _clientHost.Initialize(this);
             _client.Initialize(this);


### PR DESCRIPTION
`Initialize()` calls `SteamClient.Init()` directly. Facepunch's `SteamClient.Init` throws when Steam can't initialize: the Steam client is still starting up, isn't running, or reports `ConnectToGlobalUser failed` (which happens in sandboxed or no-logged-in-user environments). Facepunch's documentation notes that callers are expected to catch this.

FishNet runs the transport's `Initialize()` from inside `NetworkManager.Awake()`, and `NetworkManager` is marked `[DefaultExecutionOrder(short.MinValue)]`, so it runs before any other script. An uncaught throw here aborts `NetworkManager.Awake()`, which leaves every FishNet manager half-initialized. The client tick then throws a `NullReferenceException` in `PredictionManager.ReconcileToStates()` on every frame.

I hit this in a shipped build: when Steam failed to initialize, the game showed a black screen after the title and the player log filled with per-frame NREs.

This wraps the Steam init in try/catch. On failure the transport comes up without Steam (hosting and joining over Steam are unavailable, which is correct when Steam is down), but `NetworkManager.Awake()` completes normally and the game still starts. Behavior is unchanged when Steam initializes successfully.